### PR TITLE
fix(java): Fix the issue caused by not using readCompressedBytesString during deserialization when string compression is enabled.

### DIFF
--- a/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/org/apache/fury/serializer/StringSerializer.java
@@ -182,7 +182,11 @@ public final class StringSerializer extends ImmutableSerializer<String> {
   public Expression readStringExpr(Expression strSerializer, Expression buffer) {
     if (isJava) {
       if (STRING_VALUE_FIELD_IS_BYTES) {
-        return new Invoke(strSerializer, "readBytesString", STRING_TYPE, buffer);
+        if (compressString) {
+          return new Invoke(strSerializer, "readCompressedBytesString", STRING_TYPE, buffer);
+        } else {
+          return new Invoke(strSerializer, "readBytesString", STRING_TYPE, buffer);
+        }
       } else {
         if (!STRING_VALUE_FIELD_IS_CHARS) {
           throw new UnsupportedOperationException();

--- a/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/org/apache/fury/serializer/StringSerializerTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.Data;
 import org.apache.fury.Fury;
 import org.apache.fury.FuryTestBase;
 import org.apache.fury.collection.Tuple2;
@@ -158,6 +159,35 @@ public class StringSerializerTest extends FuryTestBase {
       assertEquals(str, serializer.readJavaString(buffer));
       Assert.assertEquals(buffer.writerIndex(), buffer.readerIndex());
     }
+  }
+
+  @Data
+  public static class Simple {
+    private String str;
+
+    public Simple(String str) {
+      this.str = str;
+    }
+  }
+
+  /** Test for <a href="https://github.com/apache/fury/issues/1984">#1984</a> */
+  @Test
+  public void testJavaCompressedString() {
+    Fury fury =
+        Fury.builder()
+            .withStringCompressed(true)
+            .withLanguage(Language.JAVA)
+            .requireClassRegistration(false)
+            .build();
+
+    Simple a =
+        new Simple(
+            "STG@ON DEMAND Solutions@GeoComputing Switch/ Hub@Digi Edgeport/216 – 16 port Serial Hub");
+
+    byte[] bytes = fury.serialize(a);
+
+    Simple b = (Simple) fury.deserialize(bytes);
+    assertEquals(a, b);
   }
 
   @Test(dataProvider = "stringCompress")


### PR DESCRIPTION
Fix the issue caused by not using readCompressedBytesString during deserialization when string compression is enabled.

<!--
**Thanks for contributing to Fury.**

**If this is your first time opening a PR on fury, you can refer to [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).**

Contribution Checklist

    - The **Apache Fury (incubating)** community has restrictions on the naming of pr titles. You can also find instructions in [CONTRIBUTING.md](https://github.com/apache/fury/blob/main/CONTRIBUTING.md).

    - Fury has a strong focus on performance. If the PR you submit will have an impact on performance, please benchmark it first and provide the benchmark result here.
-->

## What does this PR do?

[#1984](https://github.com/apache/fury/issues/1984)
<!-- Describe the purpose of this PR. -->

## Related issues

<!--
Is there any related issue? Please attach here.

- #xxxx0
- #xxxx1
- #xxxx2
-->

## Does this PR introduce any user-facing change?

<!--
If any user-facing interface changes, please [open an issue](https://github.com/apache/fury/issues/new/choose) describing the need to do so and update the document if necessary.
-->

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

## Benchmark

<!--
When the PR has an impact on performance (if you don't know whether the PR will have an impact on performance, you can submit the PR first, and if it will have impact on performance, the code reviewer will explain it), be sure to attach a benchmark data here.
-->
